### PR TITLE
update metrics syntax and rename to convention

### DIFF
--- a/__tests__/context.js
+++ b/__tests__/context.js
@@ -37,7 +37,9 @@ test('PodiumContext() - no value given to "name" - should throw', () => {
     expect.hasAssertions();
     expect(() => {
         const context = new Context(); // eslint-disable-line no-unused-vars
-    }).toThrowError('The value, "undefined", for the required argument "name" on the Context constructor is not defined or not valid.');
+    }).toThrowError(
+        'The value, "undefined", for the required argument "name" on the Context constructor is not defined or not valid.',
+    );
 });
 
 /**
@@ -252,5 +254,6 @@ test('PodiumContext.middleware() - timing success metric produced', async () => 
 
     expect(metrics).toHaveLength(1);
     expect(metrics[0].timestamp).not.toBeFalsy();
-    expect(metrics[0].name).toEqual('context_run_parsers');
+    expect(metrics[0].type).toBe(5);
+    expect(metrics[0].name).toBe('podium_context_process');
 });

--- a/lib/context.js
+++ b/lib/context.js
@@ -27,9 +27,10 @@ const PodiumContext = class PodiumContext {
         locale = {},
         debug = {},
     } = {}) {
-        if (validate.name(name).error) throw new Error(
-            `The value, "${name}", for the required argument "name" on the Context constructor is not defined or not valid.`
-        );
+        if (validate.name(name).error)
+            throw new Error(
+                `The value, "${name}", for the required argument "name" on the Context constructor is not defined or not valid.`,
+            );
 
         Object.defineProperty(this, 'log', {
             value: abslog(logger),
@@ -44,7 +45,10 @@ const PodiumContext = class PodiumContext {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/context module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/context module',
+                error,
+            );
         });
 
         this.register('publicPathname', new PublicPathname(publicPathname));
@@ -88,10 +92,12 @@ const PodiumContext = class PodiumContext {
             throw TypeError('Argument must be of type "PodiumHttpIncoming"');
         }
 
-        const timer = this.metrics.timer({
-            name: 'context_run_parsers',
-            description: 'Time taken to run all context parsers',
+        const histogram = this.metrics.histogram({
+            name: 'podium_context_process',
+            description:
+                'Time taken to run all context parsers in the process method',
         });
+        const timer = histogram.timer();
 
         const parsers = Array.from(this.parsers);
         return Promise.all(


### PR DESCRIPTION
* uses new `@metrics/client` metric syntax
* renames metric name to meet new podium metric naming convention of
`podium_<repo>_<module/class>_method`