### PR TITLE
add Podium context invisible getters for convenience and consistency

### DIFF
--- a/__tests__/context.js
+++ b/__tests__/context.js
@@ -225,13 +225,7 @@ test('PodiumContext.middleware() - process a "minimal" request - should put pars
 
 test('PodiumContext.middleware() - context object getters not present when serializing', async () => {
     const context = new Context({ name: 'foo' });
-    const incoming = new HttpIncoming({
-        headers: {
-            host: 'localhost:3030',
-        },
-        hostname: 'localhost',
-        url: '/some/path',
-    });
+    const incoming = new HttpIncoming();
 
     const result = await context.process(incoming);
 

--- a/__tests__/context.js
+++ b/__tests__/context.js
@@ -185,6 +185,13 @@ test('PodiumContext.middleware() - process a "rich" request - should put parsed 
     expect(result.context['podium-debug']).toEqual('false');
     expect(result.context['podium-requested-by']).toEqual('foo');
     expect(result.context['podium-public-pathname']).toBeInstanceOf(Function);
+    expect(result.context.mountOrigin).toEqual('http://localhost:3030');
+    expect(result.context.mountPathname).toEqual('/');
+    expect(result.context.deviceType).toEqual('mobile');
+    expect(result.context.locale).toEqual('en-US');
+    expect(result.context.debug).toEqual('false');
+    expect(result.context.requestedBy).toEqual('foo');
+    expect(result.context.publicPathname).toBeInstanceOf(Function);
 });
 
 test('PodiumContext.middleware() - process a "minimal" request - should put parsed values into res.locals.podium', async () => {
@@ -207,6 +214,36 @@ test('PodiumContext.middleware() - process a "minimal" request - should put pars
     expect(result.context['podium-debug']).toEqual('false');
     expect(result.context['podium-requested-by']).toEqual('foo');
     expect(result.context['podium-public-pathname']).toBeInstanceOf(Function);
+    expect(result.context.mountOrigin).toEqual('http://localhost:3030');
+    expect(result.context.mountPathname).toEqual('/');
+    expect(result.context.deviceType).toEqual('desktop');
+    expect(result.context.locale).toEqual('en-US');
+    expect(result.context.debug).toEqual('false');
+    expect(result.context.requestedBy).toEqual('foo');
+    expect(result.context.publicPathname).toBeInstanceOf(Function);
+});
+
+test('PodiumContext.middleware() - context object getters not present when serializing', async () => {
+    const context = new Context({ name: 'foo' });
+    const incoming = new HttpIncoming({
+        headers: {
+            host: 'localhost:3030',
+        },
+        hostname: 'localhost',
+        url: '/some/path',
+    });
+
+    const result = await context.process(incoming);
+
+    expect(Object.keys(result.context)).toEqual([
+        'podium-public-pathname',
+        'podium-mount-pathname',
+        'podium-mount-origin',
+        'podium-requested-by',
+        'podium-device-type',
+        'podium-locale',
+        'podium-debug',
+    ]);
 });
 
 test('PodiumContext.middleware() - a parser throws - should emit "next()" with Boom Error Object', async () => {

--- a/lib/context.js
+++ b/lib/context.js
@@ -110,6 +110,14 @@ const PodiumContext = class PodiumContext {
                 const key = `${PREFIX}-${parsers[index][0]}`;
                 // eslint-disable-next-line no-param-reassign
                 incoming.context[decamelize(key, '-')] = item;
+
+                Object.defineProperty(incoming.context, parsers[index][0], {
+                    get() {
+                        return incoming.context[decamelize(key, '-')];
+                    },
+                    enumerable: false,
+                    configurable: false,
+                });
             });
 
             timer();


### PR DESCRIPTION
## Overview

Here is a proposal to make switching between podlet and layout accessing of the context a little more consistent. I realise that they can't entirely be the same due to the need for fetch values to be respected in some cases. (eg. public pathname) but this seemed like a possible way to avoid the confusion when accessing context values in a layout route.

## What?

This PR adds an "invisible" getter property (get only, no write, non enumerable) for each parser using the registered key as the property. Since these are non enumerable, they will not show up in any serialisation.

## Why?

It's confusing to users to have to access context values via a snake case string that also must include `podium-` at the beginning. Eg. `res.locals.podium.context['podium-finn-token']`

## Example

```js
layout.context.register('finnToken', new FinnTokenParser());

app.get('/', (req, res) => {
    // this is confusing, especially when it's different in the podlet
    const finnToken = res.locals.podium.context['podium-finn-token'];

   // this PR makes it possible to do this
    const finnToken = res.locals.podium.context.finnToken;
});
```

## Caveat

If a parser is a function, the getter will still return the function, it will not call the function so there is still room for some inconsistency between the layout and the podlet.

